### PR TITLE
Add scroll to bottom for History Pane

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,10 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Gulp hygiene-branch",
+            "name": "Gulp watch",
             "program": "${workspaceFolder}/node_modules/gulp/bin/gulp.js",
             "args": [
-                "hygiene-branch"
+                "watch"
             ]
         },
         {

--- a/src/client/datascience/history-react/MainPanel.tsx
+++ b/src/client/datascience/history-react/MainPanel.tsx
@@ -11,6 +11,7 @@ import { Cell } from './cell';
 
 export interface IState {
     cells: ICell[];
+    busy: boolean;
 }
 
 export interface IMainPanelProps {
@@ -22,18 +23,21 @@ export class MainPanel extends React.Component<IMainPanelProps, IState> {
     // tslint:disable-next-line:no-any
     private messageHandlers: { [index: string]: (msg?: any) => void } = {
     };
+    private bottom: HTMLDivElement | undefined;
 
     // tslint:disable-next-line:max-func-body-length
     constructor(props: IMainPanelProps, state: IState) {
         super(props);
-        this.state = { cells: [] };
+        this.state = { cells: [], busy: false };
         this.updateState.bind(this);
         this.messageHandlers[HistoryMessages.UpdateState] = this.updateState;
 
         // Setup up some dummy cells for debugging when not running in vscode
         // This should show a gray rectangle in the cell.
         if (!PostOffice.canSendMessages() && !this.props.skipDefault) {
-            this.state = {cells: [
+            this.state = {
+                busy: false,
+                cells: [
                 {
                     input: 'get_ipython().run_line_magic("matplotlib", "inline")',
                     output: {
@@ -168,11 +172,20 @@ export class MainPanel extends React.Component<IMainPanelProps, IState> {
         }
     }
 
+    public componentDidMount() {
+        this.scrollToBottom();
+    }
+
+    public componentDidUpdate(prevProps, prevState) {
+        this.scrollToBottom();
+    }
+
     public render() {
         return (
             <div className='main-panel'>
                 <PostOffice messageHandlers={this.messageHandlers} />
                 {this.renderCells()}
+                <div ref={this.updateBottom} />
             </div>
         );
     }
@@ -183,6 +196,16 @@ export class MainPanel extends React.Component<IMainPanelProps, IState> {
                 <Cell input={cell.input} output={cell.output} id={cell.id} />
             </ErrorBoundary>
         );
+    }
+
+    private scrollToBottom = () => {
+        if (this.bottom) {
+            this.bottom.scrollIntoView({behavior: 'smooth'});
+        }
+    }
+
+    private updateBottom = (newBottom: HTMLDivElement) => {
+        this.bottom = newBottom;
     }
 
     // tslint:disable-next-line:no-any


### PR DESCRIPTION
Adds scrollToBottom by sticking a hidden div that can be scrolled to.

<!--
  If an item below does not apply to you, then go ahead and check it off as "done" and strikethrough the text, e.g.:
    - [x] ~Has unit tests & system/integration tests~
-->
- [x] Pull request represents a single change (i.e. not fixing disparate/unrelated things in a single PR)
- [x] Title summarizes what is changing
- [x] ~Has a [news entry](https://github.com/Microsoft/vscode-python/tree/master/news) file (remember to thank yourself!)
- [ ] Unit tests & system/integration tests are added/updated
- [x] Any new/changed dependencies in [`package.json`](https://github.com/Microsoft/vscode-python/blob/master/package.json) are pinned (e.g. `"1.2.3"`, not `"^1.2.3"` for the specified version)
- [x] [`package-lock.json`](https://github.com/Microsoft/vscode-python/blob/master/package-lock.json) has been regenerated by running `npm install` (if dependencies have changed)
