### PR TITLE
Fix Windows Conda detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12533,7 +12533,7 @@
         },
         "pretty-hrtime": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
             "dev": true
         },

--- a/src/client/datascience/jupyterAvailability.ts
+++ b/src/client/datascience/jupyterAvailability.ts
@@ -4,20 +4,39 @@
 import { inject, injectable } from 'inversify';
 
 import { IPythonExecutionFactory } from '../common/process/types';
-import { IJupyterAvailability } from './types';
+import { IJupyterExecution } from './types';
+import { ExecutionResult, ObservableExecutionResult, SpawnOptions } from '../common/process/types';
+import { IPlatformService } from '../common/platform/types';
+import { IConfigurationService } from '../common/types';
+import { ICondaService } from '../interpreter/contracts';
 
 @injectable()
-export class JupyterAvailability implements IJupyterAvailability {
+export class JupyterExecution implements IJupyterExecution {
 
-    constructor(@inject(IPythonExecutionFactory) private executionFactory: IPythonExecutionFactory) {
+    constructor(@inject(IPythonExecutionFactory) private executionFactory: IPythonExecutionFactory,
+                @inject(IPlatformService) private platformService: IPlatformService,
+                @inject(IConfigurationService) private configuration: IConfigurationService,
+                @inject(ICondaService) private condaService: ICondaService) {
+    }
 
+    public execModuleObservable = async (args: string[], options: SpawnOptions): Promise<ObservableExecutionResult<string>> => {
+        const newOptions = await this.fixupCondaEnv(options);
+        const pythonService = await this.executionFactory.create({});
+        return pythonService.execModuleObservable('jupyter', args, newOptions);
+    }
+    public execModule = async (args: string[], options: SpawnOptions): Promise<ExecutionResult<string>> => {
+        const newOptions = await this.fixupCondaEnv(options);
+        const pythonService = await this.executionFactory.create({});
+        return pythonService.execModule('jupyter', args, newOptions);
     }
 
     public isNotebookSupported = async (): Promise<boolean> => {
         // Spawn jupyter notebook --version and see if it returns something
+        const newOptions = await this.fixupCondaEnv({ throwOnStdErr: true, encoding: 'utf8' });
+        const args = ['notebook', '--version'];
+
         try {
-            const pythonService = await this.executionFactory.create({});
-            const result = await pythonService.execModule('jupyter', ['notebook', '--version'], { throwOnStdErr: true, encoding: 'utf8' });
+            const result = await this.execModule(args, newOptions);
             return (!result.stderr);
         } catch {
             return false;
@@ -26,12 +45,33 @@ export class JupyterAvailability implements IJupyterAvailability {
 
     public isImportSupported = async (): Promise<boolean> => {
         // Spawn jupyter nbconvert --version and see if it returns something
+        const newOptions = await this.fixupCondaEnv({ throwOnStdErr: true, encoding: 'utf8' });
+        const args = ['nbconvert', '--version'];
+
         try {
-            const pythonService = await this.executionFactory.create({});
-            const result = await pythonService.execModule('jupyter', ['nbconvert', '--version'], { throwOnStdErr: true, encoding: 'utf8' });
+            const result = await this.execModule(args, newOptions);
             return (!result.stderr);
         } catch {
             return false;
         }
+    }
+
+    private fixupCondaEnv = async (inputOptions: SpawnOptions): Promise<SpawnOptions> => {
+        const settings = this.configuration.getSettings();
+        const condaEnv = await this.condaService.getCondaEnvironment(settings.pythonPath);
+        if (condaEnv) {
+            if (this.platformService.isWindows) {
+                const scriptsPath = condaEnv.path.concat('\\Scripts\\;');
+                let newOptions = {...inputOptions};
+                if (newOptions.env && newOptions.env.Path) {
+                    newOptions.env.Path = scriptsPath.concat(newOptions.env.Path); 
+                } else {
+                    newOptions.env = process.env;
+                    newOptions.env.Path = scriptsPath.concat(newOptions.env.Path); 
+                }
+                return newOptions;
+            }
+        }
+        return inputOptions;
     }
 }

--- a/src/client/datascience/jupyterImporter.ts
+++ b/src/client/datascience/jupyterImporter.ts
@@ -11,7 +11,7 @@ import { IDisposableRegistry } from '../common/types';
 import { createDeferred, Deferred } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
 import { IInterpreterService } from '../interpreter/contracts';
-import { IJupyterAvailability, INotebookImporter } from './types';
+import { IJupyterExecution, INotebookImporter } from './types';
 
 @injectable()
 export class JupyterImporter implements INotebookImporter {
@@ -39,7 +39,7 @@ export class JupyterImporter implements INotebookImporter {
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
         @inject(IInterpreterService) private interpreterService: IInterpreterService,
-        @inject(IJupyterAvailability) private availability : IJupyterAvailability) {
+        @inject(IJupyterExecution) private jupyterExecution : IJupyterExecution) {
 
         this.settingsChangedDiposable = this.interpreterService.onDidChangeInterpreter(this.onSettingsChanged);
         this.templatePromise = this.createTemplateFile();
@@ -50,9 +50,8 @@ export class JupyterImporter implements INotebookImporter {
         const template = await this.templatePromise;
 
         // Use the jupyter nbconvert functionality to turn the notebook into a python file
-        if (await this.availability.isImportSupported()) {
-            const executionService = await this.getExecutionService();
-            const result = await executionService.execModule('jupyter', ['nbconvert', file, '--to', 'python', '--stdout', '--template', template], { throwOnStdErr: false, encoding: 'utf8' });
+        if (await this.jupyterExecution.isImportSupported()) {
+            const result = await this.jupyterExecution.execModule(['nbconvert', file, '--to', 'python', '--stdout', '--template', template], { throwOnStdErr: false, encoding: 'utf8' });
             if (result.stdout.trim().length === 0) {
                 throw result.stderr;
             }

--- a/src/client/datascience/jupyterProcess.ts
+++ b/src/client/datascience/jupyterProcess.ts
@@ -9,7 +9,7 @@ import { URL } from 'url';
 import { ExecutionResult, IPythonExecutionFactory, ObservableExecutionResult, Output } from '../common/process/types';
 import { ILogger } from '../common/types';
 import { createDeferred, Deferred } from '../common/utils/async';
-import { INotebookProcess } from './types';
+import { IJupyterExecution, INotebookProcess } from './types';
 
 export interface IConnectionInfo {
     baseUrl: string;
@@ -26,6 +26,7 @@ export class JupyterProcess implements INotebookProcess {
 
     constructor(
         @inject(IPythonExecutionFactory) private executionFactory: IPythonExecutionFactory,
+        @inject(IJupyterExecution) private jupyterExecution : IJupyterExecution,
         @inject(ILogger) private logger: ILogger) {
     }
 
@@ -38,12 +39,11 @@ export class JupyterProcess implements INotebookProcess {
         this.startPromise = createDeferred<IConnectionInfo>();
 
         // Use the IPythonExecutionService to find Jupyter
-        const pythonService = await this.executionFactory.create({});
-        this.startObservable = pythonService.execModuleObservable('jupyter', args, {throwOnStdErr: false, encoding: 'utf8'});
+        this.startObservable = await this.jupyterExecution.execModuleObservable(args, { throwOnStdErr: false, encoding: 'utf8'});
 
         // Listen on stderr for its connection information
         this.startObservable.out.subscribe((output : Output<string>) => {
-            if (output.source === 'stderr') {
+            if (output.source === 'stderr') { 
                 this.extractConnectionInformation(output.out);
             } else {
                 this.output(output.out);
@@ -66,8 +66,7 @@ export class JupyterProcess implements INotebookProcess {
         const args: string [] = ['notebook', `--NotebookApp.file_to_run=${notebookFile}`];
 
         // Use the IPythonExecutionService to find Jupyter
-        const pythonService = await this.executionFactory.create({});
-        return pythonService.execModule('jupyter', args, {throwOnStdErr: true, encoding: 'utf8'});
+        return this.jupyterExecution.execModule(args, {throwOnStdErr: true, encoding: 'utf8'});
     }
 
     public async waitForPythonVersionString() : Promise<string> {

--- a/src/client/datascience/jupyterServer.ts
+++ b/src/client/datascience/jupyterServer.ts
@@ -17,7 +17,7 @@ import { IDisposableRegistry, ILogger } from '../common/types';
 import { createDeferred } from '../common/utils/async';
 import * as localize from '../common/utils/localize';
 import { RegExpValues } from './constants';
-import { CellState, ICell, IJupyterAvailability, INotebookProcess, INotebookServer } from './types';
+import { CellState, ICell, IJupyterExecution, INotebookProcess, INotebookServer } from './types';
 
 // This code is based on the examples here:
 // https://www.npmjs.com/package/@jupyterlab/services
@@ -34,12 +34,12 @@ export class JupyterServer implements INotebookServer {
         @inject(INotebookProcess) private process: INotebookProcess,
         @inject(IFileSystem) private fileSystem: IFileSystem,
         @inject(IDisposableRegistry) private disposableRegistry: IDisposableRegistry,
-        @inject(IJupyterAvailability) private availability : IJupyterAvailability) {
+        @inject(IJupyterExecution) private jupyterExecution : IJupyterExecution) {
     }
 
     public start = async () : Promise<boolean> => {
 
-        if (await this.availability.isNotebookSupported()) {
+        if (await this.jupyterExecution.isNotebookSupported()) {
 
             // First generate a temporary notebook. We need this as input to the session
             this.tempFile = await this.generateTempFile();

--- a/src/client/datascience/serviceRegistry.ts
+++ b/src/client/datascience/serviceRegistry.ts
@@ -8,7 +8,7 @@ import { DataScienceCodeLensProvider } from './editor-integration/codelensprovid
 import { History } from './history';
 import { HistoryCommandListener } from './historyCommandListener';
 import { HistoryProvider } from './historyprovider';
-import { JupyterAvailability } from './jupyterAvailability';
+import { JupyterExecution } from './jupyterAvailability';
 import { JupyterImporter } from './jupyterImporter';
 import { JupyterProcess } from './jupyterProcess';
 import { JupyterServer } from './jupyterServer';
@@ -19,7 +19,7 @@ import {
     IDataScienceCommandListener,
     IHistory,
     IHistoryProvider,
-    IJupyterAvailability,
+    IJupyterExecution,
     INotebookImporter,
     INotebookProcess,
     INotebookServer
@@ -28,7 +28,7 @@ import {
 export function registerTypes(serviceManager: IServiceManager) {
     serviceManager.addSingleton<IDataScienceCodeLensProvider>(IDataScienceCodeLensProvider, DataScienceCodeLensProvider);
     serviceManager.addSingleton<IDataScience>(IDataScience, DataScience);
-    serviceManager.addSingleton<IJupyterAvailability>(IJupyterAvailability, JupyterAvailability);
+    serviceManager.addSingleton<IJupyterExecution>(IJupyterExecution, JupyterExecution);
     serviceManager.add<IDataScienceCommandListener>(IDataScienceCommandListener, HistoryCommandListener);
     serviceManager.addSingleton<IHistoryProvider>(IHistoryProvider, HistoryProvider);
     serviceManager.add<IHistory>(IHistory, History);

--- a/src/client/datascience/types.ts
+++ b/src/client/datascience/types.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs/Observable';
 import { CodeLens, CodeLensProvider, Event, Range, TextDocument, TextEditor } from 'vscode';
 
 import { ICommandManager } from '../common/application/types';
-import { ExecutionResult } from '../common/process/types';
+import { ExecutionResult, ObservableExecutionResult, SpawnOptions } from '../common/process/types';
 import { IConnectionInfo } from './jupyterProcess';
 
 // Main interface
@@ -45,10 +45,12 @@ export interface INotebookProcess extends IDisposable {
     spawn(notebookFile: string) : Promise<ExecutionResult<string>>;
 }
 
-export const IJupyterAvailability = Symbol('IJupyterAvailablity');
-export interface IJupyterAvailability {
+export const IJupyterExecution = Symbol('IJupyterAvailablity');
+export interface IJupyterExecution {
     isNotebookSupported() : Promise<boolean>;
     isImportSupported() : Promise<boolean>;
+    execModuleObservable(args: string[], options: SpawnOptions) : Promise<ObservableExecutionResult<string>>;
+    execModule(args: string[], options: SpawnOptions) : Promise<ExecutionResult<string>>;
 }
 
 export const INotebookImporter = Symbol('INotebookImporter');

--- a/src/client/interpreter/locators/services/condaService.ts
+++ b/src/client/interpreter/locators/services/condaService.ts
@@ -281,7 +281,7 @@ export class CondaService implements ICondaService {
             const interpreters = await this.registryLookupForConda.getInterpreters();
             const condaInterpreters = interpreters.filter(this.detectCondaEnvironment);
             const condaInterpreter = this.getLatestVersion(condaInterpreters);
-            const condaPath = condaInterpreter ? path.join(path.dirname(condaInterpreter.path), 'conda.exe') : '';
+            const condaPath = condaInterpreter ? path.join(path.dirname(condaInterpreter.path), 'Scripts\\conda.exe') : '';
             if (await fileSystem.fileExists(condaPath)) {
                 return condaPath;
             }

--- a/src/test/datascience/dataScienceIocContainer.ts
+++ b/src/test/datascience/dataScienceIocContainer.ts
@@ -11,7 +11,7 @@ import { IConfigurationService, ICurrentProcess, ILogger, IPythonSettings } from
 import { CodeCssGenerator } from '../../client/datascience/codeCssGenerator';
 import { History } from '../../client/datascience/history';
 import { HistoryProvider } from '../../client/datascience/historyprovider';
-import { JupyterAvailability } from '../../client/datascience/jupyterAvailability';
+import { JupyterExecution } from '../../client/datascience/jupyterAvailability';
 import { JupyterImporter } from '../../client/datascience/jupyterImporter';
 import { JupyterProcess } from '../../client/datascience/jupyterProcess';
 import { JupyterServer } from '../../client/datascience/jupyterServer';
@@ -19,7 +19,7 @@ import {
     ICodeCssGenerator,
     IHistory,
     IHistoryProvider,
-    IJupyterAvailability,
+    IJupyterExecution,
     INotebookImporter,
     INotebookProcess,
     INotebookServer
@@ -35,7 +35,7 @@ export class DataScienceIocContainer extends UnitTestIocContainer {
 
     public registerDataScienceTypes() {
         this.registerFileSystemTypes();
-        this.serviceManager.addSingleton<IJupyterAvailability>(IJupyterAvailability, JupyterAvailability);
+        this.serviceManager.addSingleton<IJupyterExecution>(IJupyterExecution, JupyterExecution);
         this.serviceManager.addSingleton<IHistoryProvider>(IHistoryProvider, HistoryProvider);
         this.serviceManager.add<IHistory>(IHistory, History);
         this.serviceManager.add<INotebookImporter>(INotebookImporter, JupyterImporter);

--- a/src/test/datascience/history.functional.unit.test.tsx
+++ b/src/test/datascience/history.functional.unit.test.tsx
@@ -13,7 +13,7 @@ import {
     IWebPanelProvider,
     WebPanelMessage
 } from '../../client/common/application/types';
-import { IHistoryProvider, IJupyterAvailability } from '../../client/datascience/types';
+import { IHistoryProvider, IJupyterExecution } from '../../client/datascience/types';
 import { Cell } from '../../datascience-ui/history-react/cell';
 import { MainPanel } from '../../datascience-ui/history-react/mainPanel';
 import { IVsCodeApi } from '../../datascience-ui/react-common/postOffice';
@@ -23,7 +23,7 @@ import { waitForUpdate } from './reactHelpers';
 // tslint:disable-next-line:max-func-body-length
 suite('History output tests', () => {
     const disposables: Disposable[] = [];
-    let jupyterAvailability: IJupyterAvailability;
+    let jupyterExecution: IJupyterExecution;
     let webPanelProvider : TypeMoq.IMock<IWebPanelProvider>;
     let webPanel : TypeMoq.IMock<IWebPanel>;
     let historyProvider : IHistoryProvider;
@@ -51,7 +51,7 @@ suite('History output tests', () => {
         webPanel.setup(p => p.postMessage(TypeMoq.It.isAny())).callback((m : WebPanelMessage) => window.postMessage(m, '*')); // See JSDOM valid target origins
         webPanel.setup(p => p.show());
 
-        jupyterAvailability = ioc.serviceManager.get<IJupyterAvailability>(IJupyterAvailability);
+        jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
         historyProvider = ioc.serviceManager.get<IHistoryProvider>(IHistoryProvider);
 
         // Setup a global for the acquireVsCodeApi so that the React PostOffice can find it
@@ -91,7 +91,7 @@ suite('History output tests', () => {
     });
 
     test('Simple text', async () => {
-        if (await jupyterAvailability.isNotebookSupported()) {
+        if (await jupyterExecution.isNotebookSupported()) {
             // Create our main panel and tie it into the JSDOM
             const wrapper = mount(<MainPanel theme='vscode-light' skipDefault={true} />);
 

--- a/src/test/datascience/notebook.functional.unit.test.ts
+++ b/src/test/datascience/notebook.functional.unit.test.ts
@@ -5,12 +5,12 @@ import { nbformat } from '@jupyterlab/coreutils';
 import * as assert from 'assert';
 import { Disposable } from 'vscode';
 
-import { IJupyterAvailability, INotebookServer } from '../../client/datascience/types';
+import { IJupyterExecution, INotebookServer } from '../../client/datascience/types';
 import { DataScienceIocContainer } from './dataScienceIocContainer';
 
 suite('Jupyter notebook tests', () => {
     const disposables: Disposable[] = [];
-    let availability: IJupyterAvailability;
+    let jupyterExecution: IJupyterExecution;
     let jupyterServer : INotebookServer;
     let ioc: DataScienceIocContainer;
 
@@ -18,7 +18,7 @@ suite('Jupyter notebook tests', () => {
         ioc = new DataScienceIocContainer();
         ioc.registerDataScienceTypes();
         jupyterServer = ioc.serviceManager.get<INotebookServer>(INotebookServer);
-        availability = ioc.serviceManager.get<IJupyterAvailability>(IJupyterAvailability);
+        jupyterExecution = ioc.serviceManager.get<IJupyterExecution>(IJupyterExecution);
     });
 
     teardown(() => {
@@ -30,7 +30,7 @@ suite('Jupyter notebook tests', () => {
     });
 
     test('Creation', async () => {
-        if (await availability.isNotebookSupported()) {
+        if (await jupyterExecution.isNotebookSupported()) {
             const server = await jupyterServer.start();
             if (!server) {
                 assert.fail('Server not created');
@@ -42,7 +42,7 @@ suite('Jupyter notebook tests', () => {
     }).timeout(60000);
 
     test('Execution', async () => {
-        if (await availability.isNotebookSupported()) {
+        if (await jupyterExecution.isNotebookSupported()) {
             const server = await jupyterServer.start();
             if (!server) {
                 assert.fail('Server not created');

--- a/src/test/unittests/serviceRegistry.ts
+++ b/src/test/unittests/serviceRegistry.ts
@@ -8,14 +8,14 @@ import { IProcessServiceFactory } from '../../client/common/process/types';
 import { CodeCssGenerator } from '../../client/datascience/codeCssGenerator';
 import { History } from '../../client/datascience/history';
 import { HistoryProvider } from '../../client/datascience/historyprovider';
-import { JupyterAvailability } from '../../client/datascience/jupyterAvailability';
+import { JupyterExecution } from '../../client/datascience/jupyterAvailability';
 import { JupyterImporter } from '../../client/datascience/jupyterImporter';
 import { JupyterServer } from '../../client/datascience/jupyterServer';
 import {
     ICodeCssGenerator,
     IHistory,
     IHistoryProvider,
-    IJupyterAvailability,
+    IJupyterExecution,
     INotebookImporter,
     INotebookServer
 } from '../../client/datascience/types';
@@ -140,7 +140,7 @@ export class UnitTestIocContainer extends IocContainer {
     }
 
     public registerDataScienceTypes() {
-        this.serviceManager.addSingleton<IJupyterAvailability>(IJupyterAvailability, JupyterAvailability);
+        this.serviceManager.addSingleton<IJupyterExecution>(IJupyterExecution, JupyterExecution);
         this.serviceManager.addSingleton<IHistoryProvider>(IHistoryProvider, HistoryProvider);
         this.serviceManager.add<IHistory>(IHistory, History);
         this.serviceManager.add<INotebookImporter>(INotebookImporter, JupyterImporter);


### PR DESCRIPTION
* When conda is not in the path on windows look for it in the \\Scripts\\ directory, not in the interpreter path directory
* Add in the conda scripts directory when we exec on jupyter to correctly pick up the notebook and scripts if they are not in the path. 
* Refactor jupyter availability to be jupyter execution so we can control access to when we call 'jupyter'